### PR TITLE
mb-seed-urls-to-release-recordings: add support for "ended" when seeding url relations to release recordings

### DIFF
--- a/scripts/mb-seed-urls-to-release-recordings/src/apply-relationships.ts
+++ b/scripts/mb-seed-urls-to-release-recordings/src/apply-relationships.ts
@@ -34,7 +34,7 @@ export function applyRelationships(
                 begin_date: null, // TODO: support?
                 end_date: null, // TODO: support?
                 editsPending: false,
-                ended: false,
+                ended: !!relationship.ended, // defaults to false
                 entity0: relationship.recording,
                 entity0_credit: "",
                 entity1: {

--- a/scripts/mb-seed-urls-to-release-recordings/src/index.tsx
+++ b/scripts/mb-seed-urls-to-release-recordings/src/index.tsx
@@ -81,6 +81,7 @@ async function main() {
                         recording: track.recording,
                         url: rel.url,
                         linkTypeID,
+                        ended: rel.ended ?? false,
                     })
                 }
             }

--- a/scripts/mb-seed-urls-to-release-recordings/src/schema.ts
+++ b/scripts/mb-seed-urls-to-release-recordings/src/schema.ts
@@ -7,6 +7,7 @@ export const zSeedJSON = Zod.object({
         Zod.object({
             url: Zod.string().url(),
             types: Zod.array(Zod.string()), // link_type UUID
+            ended: Zod.boolean().optional(),
         }),
     ),
     note: Zod.string(),
@@ -17,6 +18,7 @@ export const zSeedJSON = Zod.object({
         Zod.array(Zod.object({ // NOTE: you cannot have multiple *same domain* URLs for a recording at once!
             url: Zod.string().url(),
             types: Zod.array(Zod.string()), // link_type UUID
+            ended: Zod.boolean().optional(),
         })),
     ),
     note: Zod.string(),


### PR DESCRIPTION
MusicBrainz supports marking URL relationships on an assortment of entities as "ended". This is useful in the event an editor has retained these IDs that are no longer valid but still wishes to preserve them. This PR enables companion scripts to provide this additional information when bulk-seeding recording URL relationships.

To use, simply provide `ended` with a true/false value as a sibling to the `url` and `types` keys in the JSON. An example excerpt is provided below:

```json
{
  "note": "",
  "version": 2,
  "recordings": {
    "930887fe-c3a5-41af-9fbd-5ec2c7786f1c": [
      {
        "url": "https://music.apple.com/jp/song/1481050378",
        "types": [
          "purchase for download",
          "streaming"
        ],
        "ended": true
      }
    ],
    "307af4d7-429a-48c3-84ae-9b4c6a86727b": [
      {
        "url": "https://music.apple.com/jp/song/1481050390",
        "types": [
          "purchase for download",
          "streaming"
        ],
        "ended": true
      }
    ]
  }
}
```

I've never opened a PR before so if I messed anything up please tell me. Thanks!